### PR TITLE
Added LibGDX own "Game" and "Screen" functionalities to the extension

### DIFF
--- a/libgdx-cardboard-core/src/com/badlogic/gdx/backends/android/CardBoardGame.java
+++ b/libgdx-cardboard-core/src/com/badlogic/gdx/backends/android/CardBoardGame.java
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright 2017 Markus Pettersson (markus.pettersson97@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
 package com.badlogic.gdx.backends.android;
 
 import com.badlogic.gdx.Gdx;

--- a/libgdx-cardboard-core/src/com/badlogic/gdx/backends/android/CardBoardGame.java
+++ b/libgdx-cardboard-core/src/com/badlogic/gdx/backends/android/CardBoardGame.java
@@ -1,0 +1,85 @@
+package com.badlogic.gdx.backends.android;
+
+import com.badlogic.gdx.Gdx;
+import com.google.vrtoolkit.cardboard.Eye;
+import com.google.vrtoolkit.cardboard.HeadTransform;
+import com.google.vrtoolkit.cardboard.Viewport;
+
+/** <p>
+ * An {@link CardBoardApplicationListener} that delegates to a {@link CardBoardScreen}. This allows
+ * an application to easily have multiple screens.
+ * </p>
+ * <p>
+ * Screens are not disposed automatically. You must handle whether you want to keep screens around
+ * or dispose of them when another screen is set.
+ * </p> */
+public abstract class CardBoardGame implements CardBoardApplicationListener {
+    protected CardBoardScreen screen;
+
+    @Override
+    public void dispose () {
+        if (screen != null) screen.hide();
+    }
+
+    @Override
+    public void pause () {
+        if (screen != null) screen.pause();
+    }
+
+    @Override
+    public void resume () {
+        if (screen != null) screen.resume();
+    }
+
+    @Override
+    public void render () {
+        if (screen != null) screen.render(Gdx.graphics.getDeltaTime());
+    }
+
+    @Override
+    public void resize (int width, int height) {
+        if (screen != null) screen.resize(width, height);
+    }
+
+    @Override
+    public void onNewFrame(HeadTransform paramHeadTransform) {
+        if (screen != null) screen.onNewFrame(paramHeadTransform);
+    }
+
+    @Override
+    public void onDrawEye(Eye paramEye) {
+        if (screen != null) screen.onDrawEye(paramEye);
+    }
+
+    @Override
+    public void onFinishFrame(Viewport paramViewport) {
+        if (screen != null) screen.onFinishFrame(paramViewport);
+    }
+
+    @Override
+    public void onRendererShutdown() {
+        if (screen != null) screen.onRendererShutdown();
+    }
+
+    @Override
+    public void onCardboardTrigger() {
+        if (screen != null) screen.onCardboardTrigger();
+    }
+
+    /** Sets the current screen. {@link CardBoardScreen#hide()} is called on any old screen, and
+     * {@link CardBoardScreen#show()} is called on the new screen, if any.
+     * @param cardBoardScreen may be {@code null} */
+    public void setScreen (CardBoardScreen cardBoardScreen) {
+        if (this.screen != null) this.screen.hide();
+        this.screen = cardBoardScreen;
+        if (this.screen != null) {
+            this.screen.show();
+            this.screen.resize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+        }
+    }
+
+    /** @return the currently active {@link CardBoardScreen}. */
+    public CardBoardScreen getScreen() {
+        return this.screen;
+    }
+}

--- a/libgdx-cardboard-core/src/com/badlogic/gdx/backends/android/CardBoardScreen.java
+++ b/libgdx-cardboard-core/src/com/badlogic/gdx/backends/android/CardBoardScreen.java
@@ -1,0 +1,27 @@
+package com.badlogic.gdx.backends.android;
+
+import com.badlogic.gdx.Screen;
+import com.google.vrtoolkit.cardboard.Eye;
+import com.google.vrtoolkit.cardboard.HeadTransform;
+import com.google.vrtoolkit.cardboard.Viewport;
+
+/** <p>
+ * Represents one of many Cardboard application screens, such as a main menu, a settings menu, the
+ * game screen and so on.
+ * </p>
+ * <p>
+ * Note that {@link #dispose()} is not called automatically.
+ * </p>
+ * @see CardBoardGame */
+public interface CardBoardScreen extends Screen {
+
+    public void onNewFrame(HeadTransform paramHeadTransform);
+
+    public void onDrawEye(Eye paramEye);
+
+    public void onFinishFrame(Viewport paramViewport);
+
+    public void onRendererShutdown();
+
+    public void onCardboardTrigger();
+}

--- a/libgdx-cardboard-core/src/com/badlogic/gdx/backends/android/CardBoardScreen.java
+++ b/libgdx-cardboard-core/src/com/badlogic/gdx/backends/android/CardBoardScreen.java
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright 2017 Markus Pettersson (markus.pettersson97@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
 package com.badlogic.gdx.backends.android;
 
 import com.badlogic.gdx.Screen;

--- a/libgdx-cardboard-core/src/com/badlogic/gdx/backends/android/CardBoardScreenAdapter.java
+++ b/libgdx-cardboard-core/src/com/badlogic/gdx/backends/android/CardBoardScreenAdapter.java
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright 2017 Markus Pettersson (markus.pettersson97@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
 package com.badlogic.gdx.backends.android;
 
 import com.google.vrtoolkit.cardboard.Eye;

--- a/libgdx-cardboard-core/src/com/badlogic/gdx/backends/android/CardBoardScreenAdapter.java
+++ b/libgdx-cardboard-core/src/com/badlogic/gdx/backends/android/CardBoardScreenAdapter.java
@@ -1,0 +1,62 @@
+package com.badlogic.gdx.backends.android;
+
+import com.google.vrtoolkit.cardboard.Eye;
+import com.google.vrtoolkit.cardboard.HeadTransform;
+import com.google.vrtoolkit.cardboard.Viewport;
+
+/** Convenience implementation of {@link CardBoardScreen}. Derive from this and only override
+ * what you need. */
+public abstract class CardBoardScreenAdapter implements CardBoardScreen {
+    @Override
+    public void render (float delta) {
+    }
+
+    @Override
+    public void resize (int width, int height) {
+    }
+
+    @Override
+    public void show () {
+    }
+
+    @Override
+    public void hide () {
+    }
+
+    @Override
+    public void pause () {
+    }
+
+    @Override
+    public void resume () {
+    }
+
+    @Override
+    public void dispose () {
+    }
+
+    @Override
+    public void onNewFrame(HeadTransform paramHeadTransform) {
+
+    }
+
+    @Override
+    public void onDrawEye(Eye paramEye) {
+
+    }
+
+    @Override
+    public void onFinishFrame(Viewport paramViewport) {
+
+    }
+
+    @Override
+    public void onRendererShutdown() {
+
+    }
+
+    @Override
+    public void onCardboardTrigger() {
+
+    }
+}


### PR DESCRIPTION
# LibGDX Game/Screen implementation
Was working on a group project where we intended to use LibGDX own [Game](https://libgdx.badlogicgames.com/nightlies/docs/api/com/badlogic/gdx/Game.html)/[Screen](https://libgdx.badlogicgames.com/nightlies/docs/api/com/badlogic/gdx/Screen.html) classes, but discovered that the extension was lacking support for this. We wrote our own (incomplete) implementation and after the project was finished I decided to add the rest of the features from CardBoardApplicationListener. Thought it might belong here!